### PR TITLE
fix: resolve 14 test failures on macOS fresh clone

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-os-desktop",
-  "version": "0.1.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-os-desktop",
-      "version": "0.1.0",
+      "version": "1.33.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@xterm/addon-fit": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamic-skill-creator",
-  "version": "1.49.2",
+  "version": "1.49.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamic-skill-creator",
-      "version": "1.49.2",
+      "version": "1.49.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",
         "@clack/prompts": "^1.0.0",
@@ -1404,9 +1404,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1421,9 +1418,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1438,9 +1432,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1455,9 +1446,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1472,9 +1460,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1489,9 +1474,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1506,9 +1488,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1523,9 +1502,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1540,9 +1516,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1557,9 +1530,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1574,9 +1544,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1591,9 +1558,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1608,9 +1572,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/git/scripts/git-state-check.sh
+++ b/src/git/scripts/git-state-check.sh
@@ -144,27 +144,29 @@ else
   BRANCH_JSON="\"${BRANCH_RAW}\""
 fi
 
-# --- Build array JSON helper ---
+# --- Build array JSON helper (Bash 3.2 compatible — no nameref) ---
 build_json_array() {
-  local -n arr=$1
-  if [ ${#arr[@]} -eq 0 ]; then
+  if [ $# -eq 0 ]; then
     echo "[]"
     return
   fi
   local result="["
-  for i in "${!arr[@]}"; do
-    if [ "$i" -gt 0 ]; then
+  local first=true
+  for item in "$@"; do
+    if [ "$first" = true ]; then
+      first=false
+    else
       result+=","
     fi
-    result+="\"${arr[$i]}\""
+    result+="\"${item}\""
   done
   result+="]"
   echo "$result"
 }
 
-STAGED_JSON=$(build_json_array STAGED_FILES)
-UNSTAGED_JSON=$(build_json_array UNSTAGED_FILES)
-UNTRACKED_JSON=$(build_json_array UNTRACKED_FILES)
+STAGED_JSON=$([ ${#STAGED_FILES[@]} -gt 0 ] && build_json_array "${STAGED_FILES[@]}" || echo "[]")
+UNSTAGED_JSON=$([ ${#UNSTAGED_FILES[@]} -gt 0 ] && build_json_array "${UNSTAGED_FILES[@]}" || echo "[]")
+UNTRACKED_JSON=$([ ${#UNTRACKED_FILES[@]} -gt 0 ] && build_json_array "${UNTRACKED_FILES[@]}" || echo "[]")
 
 # --- Output JSON ---
 cat <<ENDJSON

--- a/src/vtm/__tests__/template-system.test.ts
+++ b/src/vtm/__tests__/template-system.test.ts
@@ -83,6 +83,11 @@ beforeAll(async () => {
   );
 
   await writeFile(
+    join(tempDir, 'vision-template.md'),
+    '# {{name}}\n\nStatus: {{status}}\n\n{{vision}}',
+  );
+
+  await writeFile(
     join(tempDir, 'markdown-structure-template.md'),
     [
       '# {{title}}',
@@ -392,7 +397,7 @@ describe('createTemplateRegistry', () => {
   });
 
   it('get() returns metadata + loaded template content for a specific template', async () => {
-    const registry = createTemplateRegistry();
+    const registry = createTemplateRegistry(tempDir);
     const result = await registry.get('vision');
     expect(result).not.toBeNull();
     expect(result!.meta.name).toBe('vision');

--- a/test/git/scripts/shell-scripts.test.ts
+++ b/test/git/scripts/shell-scripts.test.ts
@@ -297,19 +297,18 @@ describe('shellcheck (SCRIPT-05)', () => {
     }
   })();
 
-  it.skipIf(!hasShellcheck)('all scripts pass shellcheck', () => {
+  it.skipIf(!hasShellcheck)('all scripts pass shellcheck', { timeout: 30000 }, () => {
     const scripts = fs.readdirSync(SCRIPTS_DIR).filter((f) => f.endsWith('.sh'));
     expect(scripts.length).toBeGreaterThanOrEqual(4);
 
-    for (const script of scripts) {
-      const scriptPath = path.join(SCRIPTS_DIR, script);
-      const result = execSync(`npx shellcheck "${scriptPath}" 2>&1`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      // shellcheck returns empty string on success
-      expect(result.trim()).toBe('');
-    }
+    // Single shellcheck invocation with all scripts to avoid repeated npx overhead
+    const scriptPaths = scripts.map((s) => `"${path.join(SCRIPTS_DIR, s)}"`).join(' ');
+    const result = execSync(`npx shellcheck ${scriptPaths} 2>&1`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    // shellcheck returns empty string on success
+    expect(result.trim()).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary

- **git-state-check.sh**: Replace `local -n` (Bash 4.3+ nameref) with positional args — macOS ships Bash 3.2, causing all 10 git-state-check tests + integration I-11 to fail
- **template-system test**: Add `vision-template.md` fixture to temp dir and pass `tempDir` to `createTemplateRegistry()` so `get('vision')` can load from disk
- **ipc-commands test**: Run `npm install` in `desktop/` so `@tauri-apps/api` is resolvable (test imports from `desktop/src/` but the package wasn't installed)
- **shellcheck test**: Batch all scripts into a single `npx shellcheck` invocation (was calling npx per-script, ~1s each via npx resolution) and increase timeout to 30s

## Test plan

- [x] `test/git/scripts/git-state-check.test.ts` — 10/10 pass (was 0/10)
- [x] `test/git/integration.test.ts` — 58/58 pass (was 57/58)
- [x] `src/vtm/__tests__/template-system.test.ts` — 52/52 pass (was 51/52)
- [x] `tests/ipc-commands.test.ts` — 19/19 pass (was 0/19)
- [x] `test/git/scripts/shell-scripts.test.ts` — 10/10 pass (was 9/10)
- [x] Full suite: 19,216 pass / 6 skipped (was 19,184 pass / 14 failed / 6 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)