### PR TITLE
fix: Windows compatibility follow-up — 3 issues audit caught late

### DIFF
--- a/src/cloud-ops/staging/config-intake.ts
+++ b/src/cloud-ops/staging/config-intake.ts
@@ -98,8 +98,12 @@ export function validateConfigFile(
         errors.push('Malformed YAML: unbalanced square brackets [ ]');
       }
 
-      // Warn if file has no document separator and appears to be a multi-doc
-      if (content.includes('---\n') && content.split('---\n').length > 2) {
+      // Warn if the file contains multiple YAML documents. Match `---` as
+      // its own line via anchored regex so the check tolerates CRLF line
+      // endings (Windows git checkout with core.autocrlf=true). The prior
+      // literal `'---\n'` split silently missed CRLF files.
+      const docSepCount = (content.match(/^---\s*$/gm) ?? []).length;
+      if (docSepCount >= 2) {
         warnings.push('File contains multiple YAML documents -- only the first will be processed by kolla-ansible');
       }
       break;

--- a/src/commands/security-init.ts
+++ b/src/commands/security-init.ts
@@ -12,7 +12,13 @@
  */
 
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
+
+// Socket path default resolved at module load — os.tmpdir() returns the
+// platform-appropriate temp dir (/tmp on Linux, /var/folders/... on macOS,
+// %LOCALAPPDATA%\Temp on Windows). Hardcoding /tmp broke Windows first-run.
+const DEFAULT_PROXY_SOCKET = path.join(os.tmpdir(), 'security-proxy.sock');
 
 // ---------------------------------------------------------------------------
 // Template content
@@ -87,7 +93,7 @@ script (Phase 373) before any agent process starts.
     "allowed_domains": [
       {"domain": "api.anthropic.com", "credential_type": "api_key_header", "credential_source": "keychain", "header_name": "x-api-key"}
     ],
-    "proxy_socket": "/tmp/security-proxy.sock"
+    "proxy_socket": "${DEFAULT_PROXY_SOCKET}"
   },
   "worktree_path": null
 }
@@ -104,7 +110,7 @@ Deserialize). No configuration change can enable credential logging.
 
 \`\`\`json
 {
-  "socket_path": "/tmp/security-proxy.sock",
+  "socket_path": "${DEFAULT_PROXY_SOCKET}",
   "allowed_domains": [],
   "log_requests": true,
   "log_credentials": false
@@ -348,12 +354,12 @@ const SANDBOX_PROFILE_TEMPLATE = {
   },
   network: {
     allowed_domains: [],
-    proxy_socket: '/tmp/security-proxy.sock',
+    proxy_socket: DEFAULT_PROXY_SOCKET,
   },
 };
 
 const PROXY_CONFIG_TEMPLATE = {
-  socket_path: '/tmp/security-proxy.sock',
+  socket_path: DEFAULT_PROXY_SOCKET,
   allowed_domains: [],
   log_requests: true,
   log_credentials: false,

--- a/src/mcp/gateway/token-manager.ts
+++ b/src/mcp/gateway/token-manager.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomBytes, timingSafeEqual } from 'node:crypto';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { TokenInfoSchema, type TokenInfo, type GatewayScope } from './types.js';
@@ -62,11 +62,24 @@ export async function readToken(tokenPath: string): Promise<TokenInfo | null> {
 /**
  * Write a token info object to the given file path.
  * Creates parent directories if they don't exist.
+ *
+ * Windows posture: fs permission mode (0o600) is only honored on POSIX.
+ * On Windows, NTFS ACLs govern access and the file inherits the parent
+ * directory's ACL — typically the user profile, which is already
+ * user-scoped. For hardened deployments, operators should run
+ * `icacls <file> /inheritance:r /grant:r "%USERNAME%:F"` out of band to
+ * strip inheritance. A native ACL fallback is deferred.
  */
 export async function writeToken(tokenPath: string, tokenInfo: TokenInfo): Promise<void> {
   const resolvedPath = resolveTokenPath(tokenPath);
   await mkdir(dirname(resolvedPath), { recursive: true });
   await writeFile(resolvedPath, JSON.stringify(tokenInfo, null, 2), { mode: 0o600 });
+  // writeFile's mode option is only applied on file creation; chmod
+  // re-asserts 0o600 even if the token file already existed with looser
+  // permissions. No-op on Windows (see JSDoc above).
+  if (process.platform !== 'win32') {
+    await chmod(resolvedPath, 0o600);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #29 addressing three Windows-compat issues the independent audit caught after merge. All three are strictly tighter / backward-compatible on Unix.

**3 commits | 3 files | +30 / -7 | Risk: LOW**

## Fixes

### 1. `security-init.ts` — hardcoded `/tmp/security-proxy.sock` (HIGH)

`SANDBOX_PROFILE_TEMPLATE` and `PROXY_CONFIG_TEMPLATE` wrote `/tmp/security-proxy.sock` verbatim into `.planning/security/*.json` on first run. On Windows this path cannot exist — the config was bogus the moment it was written.

Resolve `DEFAULT_PROXY_SOCKET` at module load via `os.tmpdir()` so templates render the platform-appropriate path:
- Linux: `/tmp/security-proxy.sock`
- macOS: `/var/folders/.../T/security-proxy.sock`
- Windows: `%LOCALAPPDATA%\Temp\security-proxy.sock`

README template interpolates the same value so generated docs match what is written to disk. **No existing tests asserted the literal**, so no test updates were required.

**Note:** `src-tauri/src/commands/security_init.rs:315,324` has the identical hardcoded literal on the Rust side. Flagged but out of scope for this TS-focused PR — needs a parallel Rust fix.

### 2. `token-manager.ts` — `writeFile({ mode: 0o600 })` not re-asserted (MEDIUM, security)

Node's `writeFile` only applies the `mode` option on **file creation**. If the token file already existed with looser permissions (manual edit, prior version, interrupted write), the fresh write preserved the old mode.

- Added explicit `chmod(resolvedPath, 0o600)` after write on POSIX so the bit is re-asserted every time.
- Documented Windows posture in JSDoc: `fs.chmod` is effectively a no-op on NTFS, the token file inherits the parent directory ACL (user profile — already user-scoped in practice). For hardened deployments, operators should run `icacls <file> /inheritance:r /grant:r "%USERNAME%:F"` out of band. A native ACL fallback is deferred.

### 3. `config-intake.ts` — CRLF bug in YAML multi-doc check (LOW)

The exact pattern PR #29 fixed in frontmatter tests, still live in production code:

\`\`\`ts
if (content.includes('---\n') && content.split('---\n').length > 2) { ... }
\`\`\`

A Windows git checkout with \`core.autocrlf=true\` produces \`---\r\n\` separators — the literal check silently misses them and the warning never fires. Replaced with \`/^---\s*\$/gm\` which matches on any line ending. Semantics preserved (warn when >= 2 separators present).

Impact is LOW because the code path is only a warning, not a parser gate.

## Test plan

- [x] \`npm test\` — 1061 files / 21,298 passed / 1 skipped / 0 failed (Linux, Node, 71.26s)
- [x] \`npx tsc --noEmit\` — clean
- [x] No existing tests touch the changed symbols; no test updates required
- [ ] CI validates on whatever matrix is configured

## Related

- Follows up #29 (merged as 061394d51)
- Independent audit discovered these items during post-merge review.