### PR TITLE
feat(examples): add rca-department chipset

### DIFF
--- a/examples/chipsets/rca-department/README.md
+++ b/examples/chipsets/rca-department/README.md
@@ -1,0 +1,341 @@
+---
+name: rca-department
+type: chipset
+category: chipset
+status: stable
+origin: tibsfox
+modified: false
+first_seen: 2026-04-14
+first_path: examples/chipsets/rca-department/README.md
+description: >
+  Coordinated root cause analysis department — five named agents, six
+  methodology skills, three teams. Retroactively completes the Session 020
+  RCA artifact suite by binding existing skills/agents/teams into the
+  forkable department template pattern.
+superseded_by: null
+---
+
+# RCA Department
+
+## 1. What is the RCA Department?
+
+The RCA Department chipset is a coordinated set of investigation agents,
+methodology skills, and pre-composed teams that together provide disciplined
+root cause analysis across classical techniques, systems-theoretic analysis,
+quantitative causal inference, human-factors frameworks, distributed-systems
+diagnostics, and blameless postmortem authoring. It targets reliability
+engineers, SREs, safety analysts, and incident commanders who need RCA to
+produce learning and accountability rather than theater.
+
+It is a department in the structural sense: incoming incidents are classified
+by a router agent (`rca-investigator`), dispatched to the specialist whose
+methodology fits the incident shape, and all work products are persisted as
+Grove records for later retrieval and cross-incident pattern detection. It
+differs from `math-department` in one deliberate way: there is no college
+concept graph binding. RCA is cross-cutting reliability infrastructure, not
+an academic discipline — see §7.
+
+## 2. Quick Start
+
+Install the chipset into your gsd-skill-creator project:
+
+```bash
+# From the gsd-skill-creator root
+cp -r examples/chipsets/rca-department .claude/chipsets/rca-department
+```
+
+The chipset is activated when any of the six skill trigger patterns match an
+incoming query (phrases like "root cause", "5 whys", "STAMP", "causal graph",
+"postmortem", etc.). `rca-investigator` (the router agent) classifies the
+incident's causal structure, domain, evidence type, and severity, then
+dispatches to the appropriate specialist. No explicit activation command is
+needed — the skill-integration layer loads the chipset based on context.
+
+To verify the chipset is recognized:
+
+```bash
+# Check that the YAML parses cleanly and lists the expected counts
+node -e "const yaml=require('yaml');const fs=require('fs'); \
+  const c=yaml.parse(fs.readFileSync('.claude/chipsets/rca-department/chipset.yaml','utf8')); \
+  console.log(c.name, '| skills:', Object.keys(c.skills).length, \
+  '| agents:', c.agents.agents.length, '| teams:', Object.keys(c.teams).length, \
+  '| grove types:', c.grove.record_types.length)"
+# Expected: rca-department-v1.0 | skills: 6 | agents: 5 | teams: 3 | grove types: 5
+```
+
+## 3. Agent Roster
+
+Five agents form the department. Three run on Opus (for judgment-heavy
+reasoning — classification, systems-theoretic analysis, quantitative causal
+inference) and two on Sonnet (for structured facilitation and drafting
+throughput).
+
+| Name                  | Role                                                                         | Model  | Tools                              | CAPCOM? |
+|-----------------------|------------------------------------------------------------------------------|--------|------------------------------------|---------|
+| rca-investigator      | Department coordinator — classification, method selection, delegation, synthesis | opus   | Read, Glob, Grep, Bash, Write, WebFetch | yes     |
+| stamp-stpa-analyst    | Systems-theoretic analyst — STPA hazard analysis and CAST retrospective investigation | opus   | Read, Write, Glob, Grep, Bash      | no      |
+| causal-graph-builder  | Causal-inference specialist — Bayesian networks, DAG construction, counterfactual estimation | opus   | Read, Write, Bash, Grep, Glob      | no      |
+| five-whys-facilitator | Classical RCA facilitator — branching 5 Whys with evidence gates and escalation guardrails | sonnet | Read, Grep, Write, Bash            | no      |
+| postmortem-writer     | Blameless postmortem author — draft generation, blameless-language audit, action-item quality gate | sonnet | Read, Write, Glob, Grep, Bash      | no      |
+
+The router topology places `rca-investigator` as the single point of contact.
+It reads the incident description and evidence, classifies along four
+dimensions (causal structure, domain, evidence type, severity/scope), picks
+one or more methodologies using Doggett's tool-selection framework, and
+dispatches to the specialists. Only `rca-investigator` is `is_capcom: true` —
+all other agents communicate through it.
+
+## 4. Skill Catalog
+
+### rca-classical-methods
+
+Classical root cause analysis techniques for quality improvement and
+incident investigation — 5 Whys (with Card's 2017 critique and boundary
+conditions), Ishikawa/fishbone diagrams, Fault Tree Analysis, FMEA, Cause
+Mapping, and Doggett's method-selection framework.
+
+- **Triggers:** `root cause`, `5 whys`, `five whys`, `fishbone`, `ishikawa`, `fault tree`, `FTA`, `FMEA`, `cause map`, `failure mode`
+- **Affinity:** `five-whys-facilitator`
+- **Source:** [`examples/skills/rca/rca-classical-methods/SKILL.md`](../../skills/rca/rca-classical-methods/SKILL.md)
+
+### rca-systems-theoretic
+
+Systems-theoretic approaches for complex socio-technical systems where
+linear causal chains fail — Leveson's STAMP/STPA/CAST, Rasmussen's dynamic
+safety model, Hollnagel's FRAM, and AcciMap.
+
+- **Triggers:** `STAMP`, `STPA`, `CAST`, `control structure`, `unsafe control action`, `Leveson`, `Rasmussen`, `FRAM`, `AcciMap`, `socio-technical`, `systems-theoretic`
+- **Affinity:** `stamp-stpa-analyst`
+- **Source:** [`examples/skills/rca/rca-systems-theoretic/SKILL.md`](../../skills/rca/rca-systems-theoretic/SKILL.md)
+
+### rca-causal-inference
+
+Mathematical foundations of RCA using Judea Pearl's Structural Causal
+Models, do-calculus, counterfactual reasoning, Bayesian networks for fault
+diagnosis, backdoor/frontdoor criteria, and information-theoretic methods
+like transfer entropy and Granger causality.
+
+- **Triggers:** `causal graph`, `causal DAG`, `Pearl`, `do-calculus`, `counterfactual`, `Bayesian network`, `backdoor criterion`, `frontdoor criterion`, `causal inference`, `transfer entropy`, `Granger causality`
+- **Affinity:** `causal-graph-builder`
+- **Source:** [`examples/skills/rca/rca-causal-inference/SKILL.md`](../../skills/rca/rca-causal-inference/SKILL.md)
+
+### rca-human-factors
+
+Human-factors RCA for incidents involving operators, crews, clinicians, or
+any human actors — James Reason's Swiss Cheese Model, HFACS, the Just
+Culture algorithm (Marx/GAIN), Crew Resource Management, and
+high-reliability organization principles.
+
+- **Triggers:** `human error`, `human factors`, `Swiss cheese`, `HFACS`, `Just Culture`, `crew resource management`, `CRM`, `operator error`, `latent failure`, `active failure`
+- **Affinity:** `rca-investigator`, `five-whys-facilitator`
+- **Source:** [`examples/skills/rca/rca-human-factors/SKILL.md`](../../skills/rca/rca-human-factors/SKILL.md)
+
+### rca-distributed-systems
+
+RCA techniques for modern microservices and cloud infrastructure —
+trace-based causality (OpenTelemetry, Jaeger, Tempo), service dependency
+graphs, DynaCausal-style dynamic causality, Microsoft AgentRx for AI agent
+failures, chaos-engineering-as-RCA, and causal-graph-based AIOps.
+
+- **Triggers:** `distributed trace`, `OpenTelemetry`, `service graph`, `microservice failure`, `cascading failure`, `DynaCausal`, `AgentRx`, `AIOps`, `partial failure`, `distributed RCA`
+- **Affinity:** `rca-investigator`, `causal-graph-builder`
+- **Source:** [`examples/skills/rca/rca-distributed-systems/SKILL.md`](../../skills/rca/rca-distributed-systems/SKILL.md)
+
+### blameless-postmortem
+
+Google SRE-style blameless postmortem authoring — structure, timeline
+construction, contributing-factor extraction, action-item discipline, and
+the cultural practices that make postmortems produce learning rather than
+theater.
+
+- **Triggers:** `postmortem`, `blameless`, `Google SRE postmortem`, `lessons learned`, `action items`, `incident report`, `what went well`, `timeline reconstruction`
+- **Affinity:** `postmortem-writer`
+- **Source:** [`examples/skills/rca/blameless-postmortem/SKILL.md`](../../skills/rca/blameless-postmortem/SKILL.md)
+
+## 5. Team Configurations
+
+### rca-deep-team
+
+- **Purpose:** Multi-method parallel investigation for SEV1/SEV2 or
+  high-uncertainty incidents. Runs classical, systems-theoretic, and
+  causal-inference analyses concurrently — plus inline human-factors and
+  distributed-systems passes by `rca-investigator` — and synthesizes the
+  findings into a single unified report.
+- **Members:** `rca-investigator`, `five-whys-facilitator`,
+  `stamp-stpa-analyst`, `causal-graph-builder`, `postmortem-writer`
+- **Use when:** SEV1/SEV2 incidents, recurring failures, conflicting
+  hypotheses, safety-critical systems, post-incident legal or regulatory
+  review.
+- **Expected session length:** 10–30 minutes wall-clock; 350–550K tokens
+  per incident. Justified only when a missed latent condition costs more
+  than the analysis.
+
+### rca-triage-team
+
+- **Purpose:** Fast triage team for routine incidents. Classifies the
+  incident, runs a single-method shallow analysis, and produces a short
+  1–2 page postmortem. Escalates to `rca-deep-team` if classification
+  confidence is low or the incident turns out to be multi-factor.
+- **Members:** `rca-investigator`, `five-whys-facilitator`,
+  `causal-graph-builder`, `postmortem-writer`
+- **Use when:** SEV3/SEV4 incidents, daily incident review, first-pass
+  classification, training mode. All Sonnet by default — no Opus.
+- **Expected session length:** 3–5 minutes wall-clock; 30–60K tokens per
+  incident. Supports bulk processing (10–20 routine incidents/day).
+
+### postmortem-team
+
+- **Purpose:** End-to-end blameless postmortem authoring and review
+  pipeline — drafting, blameless-language audit, action-item quality gate,
+  review meeting agenda generation, and asynchronous weekly tracking of
+  open action items. Focuses on the delivery side of RCA; upstream
+  investigation is handled by `rca-deep-team` or `rca-triage-team`.
+- **Members:** `postmortem-writer` (used in author, auditor, and
+  facilitator modes)
+- **Use when:** after any SEV1/SEV2 incident, after triage escalates,
+  postmortem backlog cleanup, cross-incident learning initiatives,
+  regulated environments requiring strict format.
+- **Expected session length:** ~5 minutes for draft + audit; ~30K tokens.
+  Weekly tracker is a scheduled job, not interactive.
+
+## 6. Grove Integration
+
+All department work products are persisted as Grove records under the
+`rca-department` namespace. Five record types are defined:
+
+| Record Type       | Description                                                                 |
+|-------------------|-----------------------------------------------------------------------------|
+| RCAInvestigation  | An investigation session with scope, severity, classification, and method(s) selected |
+| RCAFinding        | A single causal finding — proximate cause, contributing factor, or latent condition with evidence |
+| RCACausalGraph    | A DAG or Bayesian network relating candidate causes to outcomes, with edge annotations and effect estimates |
+| RCAPostmortem     | A blameless postmortem document with timeline, impact, causes, lessons, and action items |
+| RCASession        | Session log linking all work products (investigations, findings, graphs, postmortems) to interaction context |
+
+Records are content-addressed and immutable once written. A single
+investigation persists as a linked record set: one `RCAInvestigation`
+record, one or more `RCAFinding` and `RCACausalGraph` records produced by
+the specialists, one `RCAPostmortem` record authored by the
+`postmortem-writer`, and one `RCASession` record tying all of them back to
+the originating interaction. This provides an audit trail from incident
+evidence to final action items — useful for regulated environments and for
+cross-incident pattern detection.
+
+## 7. Why No College Integration
+
+Math, physics, and writing map naturally onto academic departments in the
+college concept graph. RCA does not. Root cause analysis is cross-cutting
+reliability infrastructure — it applies to software systems, aviation,
+healthcare, nuclear operations, financial clearing, autonomous systems, and
+any other domain where incidents happen. There is no single "RCA
+department" in the college that the chipset can bind to, and forcing a
+binding would either mis-classify the methodologies (they are not a branch
+of computer science) or bloat the college with a phantom department that
+does not correspond to any learning pathway.
+
+So this chipset deliberately opts out: `college.department: null`,
+`concept_graph.read: false`, `concept_graph.write: false`, and no wings.
+
+Forks that specialize the template to a specific applied domain — for
+example, `aviation-safety-department`, `clinical-incident-department`, or
+`financial-operations-department` — may choose to re-enable college
+binding if the fork maps onto an actual college discipline. The department
+template supports this: set `college.department` to the target, populate
+the wings, and the skill-integration layer will load the concept graph
+hooks. The baseline `rca-department` stays domain-neutral.
+
+## 8. Forking This Chipset
+
+The RCA Department follows the department template pattern. To create a
+specialized department for an adjacent reliability domain:
+
+### Step 1: Copy the chipset directory
+
+```bash
+cp -r examples/chipsets/rca-department examples/chipsets/aviation-safety-department
+```
+
+### Step 2: Rename in the YAML
+
+Edit `chipset.yaml` and update `name:` (e.g., `aviation-safety-department-v1.0`)
+and `description:`. Rename agents if the specialist roster changes (for
+aviation you might add a `crew-resource-management-analyst` and drop the
+distributed-systems affinity from the existing agents). Keep the router
+topology and `is_capcom: true` as invariants.
+
+### Step 3: Replace skills with domain-appropriate content
+
+Swap or augment the six baseline skills with domain-specific ones. For a
+clinical-incident department you might add `rca-medication-safety` and
+`rca-diagnostic-error` alongside the existing human-factors and
+systems-theoretic skills. Each new skill needs `domain`, `description`,
+`triggers`, and `agent_affinity`.
+
+### Step 4: Define new Grove record types
+
+The five baseline RCA record types are deliberately generic. Forks may
+add domain-specific types (e.g., `AviationSafetyHazardLog`,
+`ClinicalRootCauseAnalysis`) under a new Grove namespace like
+`aviation-safety-department`.
+
+### Step 5: Remap college binding (if applicable)
+
+If the fork targets a domain that has a college department, update the
+`college:` section — set `department`, enable `concept_graph.read/write`,
+and list the wings. If the fork is still cross-cutting, keep the opt-out
+from the baseline.
+
+### Step 6: Keep the evaluation gates
+
+The five pre-deploy gates (descriptions, roles, Grove types, router CAPCOM,
+methodology coverage) should be preserved. Update `benchmark.domains_covered`
+to reflect the fork's methodology list. Add domain-specific gates as
+needed (e.g., for healthcare you might add a gate requiring all agents
+to declare HIPAA-awareness).
+
+## 9. Verification
+
+Unlike `math-department` (which ships only `chipset.yaml` + `README.md` and
+leaves the evaluation gates declarative), this chipset ships an implementing
+test at `src/chipset/rca-department.test.ts` and a trigger-benchmark fixture
+at `examples/chipsets/rca-department/benchmark/test-cases.yaml`. The test
+enforces every gate listed in `chipset.yaml:evaluation.gates.pre_deploy`:
+
+- `all_skills_have_descriptions` — every skill has a non-empty description
+- `all_agents_have_roles` — every agent has a non-empty role
+- `grove_record_types_defined` — the 5 named RCA record types are present
+- `router_agent_is_capcom` — `rca-investigator` is the sole CAPCOM
+- `all_methodologies_covered` — the 5 RCA methodology skills are present
+
+Plus referential integrity checks (skill affinities and team members resolve
+to real agents; the college opt-out is explicit) and the trigger benchmark
+(the 30-case fixture is run against the skill trigger patterns and the
+aggregate accuracy is asserted against `trigger_accuracy_threshold: 0.85`).
+
+The `rca-department` Grove namespace is a new, user-chosen string. Grove's
+namespace layer (`src/mesh/grove-namespace.ts`) is a generic name → hash
+binding store with no pre-registered namespace list, so namespaces are
+chosen per chipset and collision-avoided by convention (pattern:
+`<chipset-name>`). This matches how `math-department` chose its namespace.
+
+## 10. Provenance
+
+This chipset was added on **2026-04-14** to retroactively complete the
+Session 020 RCA artifact suite. Session 020 (2026-04-11, artemis-ii
+branch) delivered the six skills, five agents, and three teams in response
+to this prompt:
+
+> "Use our local research as a guide and your own knowledge on the
+> subjects to craft a new set of skills, agents, and teams for root cause
+> analysis using current best practices and industry standards."
+
+The original Session 020 commits are `df7731df5`, `f0c7358e1`, and
+`59d271e90`. Research grounding for the skills lives at
+`docs/research/rca-deep/` (3,397 lines across six enrichment documents).
+
+What Session 020 did not produce — and what every subsequent domain bundle
+from Session 021 onward included as standard — was a chipset binding the
+artifacts into a forkable department unit. RCA predated the department
+template pattern. This chipset adds the missing binding without modifying
+any of the existing skill, agent, or team files, so the original
+investigation work remains intact and the department-template contract is
+now satisfied.

--- a/examples/chipsets/rca-department/benchmark/test-cases.yaml
+++ b/examples/chipsets/rca-department/benchmark/test-cases.yaml
@@ -1,0 +1,82 @@
+# RCA Department trigger benchmark fixture
+# 30 test cases — meets chipset.yaml: evaluation.benchmark.test_cases_minimum (25)
+# Each case is a natural-language query paired with the skill(s) that should
+# be activated. The test in src/chipset/rca-department.test.ts runs these
+# cases against the chipset's trigger patterns and asserts accuracy meets
+# evaluation.benchmark.trigger_accuracy_threshold (0.85).
+#
+# A case is counted correct when at least one expected skill matches via
+# case-insensitive substring on any of its trigger phrases.
+
+test_cases:
+  # --- rca-classical-methods (5 cases) ---
+  - query: "Run a 5 whys on the checkout outage"
+    expected_skills: [rca-classical-methods]
+  - query: "Build me a fishbone diagram for incident INC-42"
+    expected_skills: [rca-classical-methods]
+  - query: "Compute the fault tree cut sets for the pump failure"
+    expected_skills: [rca-classical-methods]
+  - query: "Run an FMEA on the new deploy pipeline"
+    expected_skills: [rca-classical-methods]
+  - query: "What's the root cause of the database latency spike?"
+    expected_skills: [rca-classical-methods]
+
+  # --- rca-systems-theoretic (5 cases) ---
+  - query: "Run STPA on the automated trading system"
+    expected_skills: [rca-systems-theoretic]
+  - query: "Perform a CAST analysis of the aviation incident"
+    expected_skills: [rca-systems-theoretic]
+  - query: "Build the control structure for this socio-technical system"
+    expected_skills: [rca-systems-theoretic]
+  - query: "Apply Leveson's STAMP to the healthcare incident"
+    expected_skills: [rca-systems-theoretic]
+  - query: "Identify the unsafe control action in the rollback workflow"
+    expected_skills: [rca-systems-theoretic]
+
+  # --- rca-causal-inference (5 cases) ---
+  - query: "Build a causal DAG from the metrics data"
+    expected_skills: [rca-causal-inference]
+  - query: "Compute the counterfactual for last Tuesday's incident"
+    expected_skills: [rca-causal-inference]
+  - query: "Apply Pearl do-calculus to this intervention question"
+    expected_skills: [rca-causal-inference]
+  - query: "Check the backdoor criterion for this causal query"
+    expected_skills: [rca-causal-inference]
+  - query: "Use Granger causality to rank the candidate causes"
+    expected_skills: [rca-causal-inference]
+
+  # --- rca-human-factors (5 cases) ---
+  - query: "Apply HFACS to the pilot error incident"
+    expected_skills: [rca-human-factors]
+  - query: "Run a Swiss cheese analysis of the medication error"
+    expected_skills: [rca-human-factors]
+  - query: "Is this a Just Culture case or a system design failure?"
+    expected_skills: [rca-human-factors]
+  - query: "This looks like operator error — dig deeper into human factors"
+    expected_skills: [rca-human-factors]
+  - query: "Evaluate the crew resource management factors"
+    expected_skills: [rca-human-factors]
+
+  # --- rca-distributed-systems (5 cases) ---
+  - query: "Trace the cascading failure across the microservice mesh"
+    expected_skills: [rca-distributed-systems]
+  - query: "Pull the distributed trace from OpenTelemetry and diagnose"
+    expected_skills: [rca-distributed-systems]
+  - query: "Build the service graph and find the partial failure source"
+    expected_skills: [rca-distributed-systems]
+  - query: "Apply AgentRx to diagnose the AI agent failure"
+    expected_skills: [rca-distributed-systems]
+  - query: "Run distributed RCA using AIOps causal graphs"
+    expected_skills: [rca-distributed-systems]
+
+  # --- blameless-postmortem (5 cases) ---
+  - query: "Draft a blameless postmortem for INC-4827"
+    expected_skills: [blameless-postmortem]
+  - query: "Write up the incident report with the Google SRE postmortem template"
+    expected_skills: [blameless-postmortem]
+  - query: "Extract the lessons learned and action items from the transcript"
+    expected_skills: [blameless-postmortem]
+  - query: "Reconstruct the timeline for the postmortem"
+    expected_skills: [blameless-postmortem]
+  - query: "What went well and what went wrong in the incident response?"
+    expected_skills: [blameless-postmortem]

--- a/examples/chipsets/rca-department/chipset.yaml
+++ b/examples/chipsets/rca-department/chipset.yaml
@@ -1,0 +1,302 @@
+# RCA Department Chipset Configuration
+# Retroactively completes the Session 020 (2026-04-11) RCA artifact suite by
+# binding 6 skills, 5 agents, and 3 teams into a forkable department bundle.
+#
+# Unlike math-department (which binds to an academic college department),
+# RCA is cross-cutting reliability infrastructure. It deliberately opts out
+# of college integration — see the `college:` section below and README §7.
+#
+# Follows the department template pattern established by math-department.
+# Other reliability-adjacent domains (aviation-safety, clinical-incident,
+# chaos-engineering) can fork this template and remap every section.
+
+name: rca-department-v1.0
+version: 1.0.0
+description: >
+  A methodology-routed root cause analysis department providing disciplined
+  incident investigation through five named agents (rca-investigator as
+  CAPCOM, plus four specialists covering classical, systems-theoretic,
+  causal-inference, and postmortem-authoring tracks), six knowledge skills
+  spanning classical RCA / STAMP-STPA / causal DAGs / human factors /
+  distributed systems / blameless postmortems, and three pre-composed teams
+  (deep, triage, postmortem). Persists investigations, findings, causal
+  graphs, postmortems, and session logs as Grove records under the
+  rca-department namespace.
+
+# ==========================================================================
+# Skills — 6 methodology skills with trigger patterns and agent affinity
+# ==========================================================================
+
+skills:
+  rca-classical-methods:
+    domain: rca
+    description: >
+      Classical root cause analysis techniques — 5 Whys (with Card's 2017
+      critique), Ishikawa/fishbone diagrams, Fault Tree Analysis, FMEA,
+      Cause Mapping, and Doggett's method-selection framework.
+    triggers:
+      - "root cause"
+      - "5 whys"
+      - "five whys"
+      - "fishbone"
+      - "ishikawa"
+      - "fault tree"
+      - "FTA"
+      - "FMEA"
+      - "cause map"
+      - "failure mode"
+    agent_affinity: five-whys-facilitator
+
+  rca-systems-theoretic:
+    domain: rca
+    description: >
+      Systems-theoretic approaches for complex socio-technical systems —
+      Leveson's STAMP/STPA/CAST, Rasmussen's dynamic safety model,
+      Hollnagel's FRAM, and AcciMap.
+    triggers:
+      - "STAMP"
+      - "STPA"
+      - "CAST"
+      - "control structure"
+      - "unsafe control action"
+      - "Leveson"
+      - "Rasmussen"
+      - "FRAM"
+      - "AcciMap"
+      - "socio-technical"
+      - "systems-theoretic"
+    agent_affinity: stamp-stpa-analyst
+
+  rca-causal-inference:
+    domain: rca
+    description: >
+      Mathematical foundations of RCA using Pearl's Structural Causal Models,
+      do-calculus, counterfactual reasoning, Bayesian networks, backdoor and
+      frontdoor criteria, transfer entropy, and Granger causality.
+    triggers:
+      - "causal graph"
+      - "causal DAG"
+      - "Pearl"
+      - "do-calculus"
+      - "counterfactual"
+      - "Bayesian network"
+      - "backdoor criterion"
+      - "frontdoor criterion"
+      - "causal inference"
+      - "transfer entropy"
+      - "Granger causality"
+    agent_affinity: causal-graph-builder
+
+  rca-human-factors:
+    domain: rca
+    description: >
+      Human-factors RCA — James Reason's Swiss Cheese Model, HFACS, the
+      Just Culture algorithm, Crew Resource Management findings, and
+      high-reliability organization principles.
+    triggers:
+      - "human error"
+      - "human factors"
+      - "Swiss cheese"
+      - "HFACS"
+      - "Just Culture"
+      - "crew resource management"
+      - "CRM"
+      - "operator error"
+      - "latent failure"
+      - "active failure"
+    agent_affinity: [rca-investigator, five-whys-facilitator]
+
+  rca-distributed-systems:
+    domain: rca
+    description: >
+      RCA techniques for microservices and cloud infrastructure — trace-based
+      causality (OpenTelemetry/Jaeger/Tempo), service-dependency graph
+      analysis, DynaCausal-style dynamic causality, Microsoft AgentRx for
+      AI agent failures, and causal-graph-based AIOps.
+    triggers:
+      - "distributed trace"
+      - "OpenTelemetry"
+      - "service graph"
+      - "microservice failure"
+      - "cascading failure"
+      - "DynaCausal"
+      - "AgentRx"
+      - "AIOps"
+      - "partial failure"
+      - "distributed RCA"
+    agent_affinity: [rca-investigator, causal-graph-builder]
+
+  blameless-postmortem:
+    domain: rca
+    description: >
+      Google SRE-style blameless postmortem authoring — structure, timeline
+      construction, contributing-factor extraction, action-item discipline,
+      and the cultural practices that make postmortems produce learning
+      rather than theater.
+    triggers:
+      - "postmortem"
+      - "blameless"
+      - "Google SRE postmortem"
+      - "lessons learned"
+      - "action items"
+      - "incident report"
+      - "what went well"
+      - "timeline reconstruction"
+    agent_affinity: postmortem-writer
+
+# ==========================================================================
+# Agents — 5 agents in router topology (rca-investigator as CAPCOM)
+# 3 Opus (deep reasoning) + 2 Sonnet (throughput)
+# ==========================================================================
+
+agents:
+  topology: "router"
+  router_agent: rca-investigator
+
+  agents:
+    - name: rca-investigator
+      role: "department coordinator — incident classification, method selection, delegation, synthesis"
+      model: opus
+      tools: [Read, Glob, Grep, Bash, Write, WebFetch]
+      is_capcom: true
+
+    - name: stamp-stpa-analyst
+      role: "systems-theoretic analyst — STPA hazard analysis and CAST retrospective investigation"
+      model: opus
+      tools: [Read, Write, Glob, Grep, Bash]
+
+    - name: causal-graph-builder
+      role: "causal-inference specialist — Bayesian networks, DAG construction, counterfactual estimation"
+      model: opus
+      tools: [Read, Write, Bash, Grep, Glob]
+
+    - name: five-whys-facilitator
+      role: "classical RCA facilitator — branching 5 Whys with evidence requirements and escalation guardrails"
+      model: sonnet
+      tools: [Read, Grep, Write, Bash]
+
+    - name: postmortem-writer
+      role: "blameless postmortem author — draft generation, blameless-language audit, action-item quality gate"
+      model: sonnet
+      tools: [Read, Write, Glob, Grep, Bash]
+
+# ==========================================================================
+# Teams — 3 pre-composed configurations
+# ==========================================================================
+
+teams:
+  rca-deep-team:
+    description: >
+      Multi-method parallel investigation for SEV1/SEV2 or high-uncertainty
+      incidents. Runs classical, systems-theoretic, causal-inference, and
+      inline human-factors + distributed-systems analyses concurrently, then
+      synthesizes findings into a unified report.
+    agents: [rca-investigator, five-whys-facilitator, stamp-stpa-analyst, causal-graph-builder, postmortem-writer]
+    use_when: "SEV1/SEV2 incidents, recurring failures, conflicting hypotheses, safety-critical systems, regulatory or legal review"
+
+  rca-triage-team:
+    description: >
+      Fast triage team for routine incidents. Classifies the incident, runs
+      a single-method shallow analysis, produces a short postmortem, and
+      escalates to rca-deep-team if the incident is deeper than it looked.
+    agents: [rca-investigator, five-whys-facilitator, causal-graph-builder, postmortem-writer]
+    use_when: "SEV3/SEV4 incidents, daily incident review, first-pass classification, training mode"
+
+  postmortem-team:
+    description: >
+      End-to-end blameless postmortem authoring and review pipeline —
+      drafting, blameless-language audit, action-item quality gate, review
+      meeting agenda generation, and asynchronous action-item tracking.
+    agents: [postmortem-writer]
+    use_when: "authoring and reviewing postmortems after investigation is complete, postmortem backlog cleanup, regulated environments requiring strict format"
+
+# ==========================================================================
+# Evaluation Gates — pre-deploy checks and benchmark thresholds
+# ==========================================================================
+
+evaluation:
+  gates:
+    pre_deploy:
+      - check: "all_skills_have_descriptions"
+        description: "Every skill must have a non-empty description"
+        action: "block"
+
+      - check: "all_agents_have_roles"
+        description: "Every agent must have a non-empty role"
+        action: "block"
+
+      - check: "grove_record_types_defined"
+        description: "All 5 RCA Grove record types documented"
+        action: "block"
+
+      - check: "router_agent_is_capcom"
+        description: "The router agent (rca-investigator) must be CAPCOM"
+        action: "block"
+
+      - check: "all_methodologies_covered"
+        description: "All 5 RCA methodologies (classical, systems-theoretic, causal-inference, human-factors, distributed-systems) must have at least one skill"
+        action: "block"
+
+  benchmark:
+    trigger_accuracy_threshold: 0.85
+    test_cases_minimum: 25
+    domains_covered:
+      - classical
+      - systems-theoretic
+      - causal-inference
+      - human-factors
+      - distributed-systems
+      - postmortem
+
+# ==========================================================================
+# Grove Integration — namespace and record types
+# ==========================================================================
+
+grove:
+  namespace: "rca-department"
+  record_types:
+    - name: RCAInvestigation
+      description: "An investigation session with scope, severity, classification, and method(s) selected"
+
+    - name: RCAFinding
+      description: "A single causal finding — proximate cause, contributing factor, or latent condition with evidence"
+
+    - name: RCACausalGraph
+      description: "A DAG or Bayesian network relating candidate causes to outcomes, with edge annotations and effect estimates"
+
+    - name: RCAPostmortem
+      description: "A blameless postmortem document with timeline, impact, causes, lessons, and action items"
+
+    - name: RCASession
+      description: "Session log linking all work products (investigations, findings, graphs, postmortems) to interaction context"
+
+# ==========================================================================
+# College Integration — deliberate opt-out
+# ==========================================================================
+#
+# RCA is cross-cutting reliability infrastructure, not an academic discipline.
+# Unlike math-department, there is no "RCA department" in the college concept
+# graph to bind to. Forks targeting a specific applied domain (e.g.,
+# aviation-safety-department, clinical-incident-department) may choose to
+# enable college binding — the department template supports it. The baseline
+# rca-department stays domain-neutral and opts out.
+
+college:
+  department: null
+  concept_graph:
+    read: false
+    write: false
+  try_session_generation: false
+  learning_pathway_updates: false
+  wings: []
+
+# ==========================================================================
+# Customization — forkable department template
+# ==========================================================================
+
+customization:
+  rename_agents: true
+  replace_skills: true
+  swap_grove_types: true
+  remap_college_department: true
+  template_pattern: "department"

--- a/src/chipset/rca-department.test.ts
+++ b/src/chipset/rca-department.test.ts
@@ -1,0 +1,217 @@
+// rca-department.test.ts — implements the declarative gates from
+// examples/chipsets/rca-department/chipset.yaml and runs the trigger
+// benchmark from examples/chipsets/rca-department/benchmark/test-cases.yaml.
+//
+// Addresses the two "declarative only" gaps in the chipset:
+//   1. evaluation.gates.pre_deploy → enforced as structural tests below
+//   2. evaluation.benchmark        → enforced against the fixture
+//
+// If either file changes, this test adjusts automatically (no hardcoded
+// counts beyond the brief's invariants: 6 / 5 / 3 / 5).
+
+import { describe, it, expect } from 'vitest';
+import { parse } from 'yaml';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+interface Skill {
+  domain: string;
+  description: string;
+  triggers: string[];
+  agent_affinity: string | string[];
+}
+
+interface Agent {
+  name: string;
+  role: string;
+  model: string;
+  tools: string[];
+  is_capcom?: boolean;
+}
+
+interface Team {
+  description: string;
+  agents: string[];
+  use_when: string;
+}
+
+interface Chipset {
+  name: string;
+  version: string;
+  skills: Record<string, Skill>;
+  agents: { topology: string; router_agent: string; agents: Agent[] };
+  teams: Record<string, Team>;
+  evaluation: {
+    gates: { pre_deploy: Array<{ check: string; action: string }> };
+    benchmark: {
+      trigger_accuracy_threshold: number;
+      test_cases_minimum: number;
+      domains_covered: string[];
+    };
+  };
+  grove: { namespace: string; record_types: Array<{ name: string; description: string }> };
+  college: {
+    department: string | null;
+    concept_graph: { read: boolean; write: boolean };
+    wings: string[];
+  };
+}
+
+interface TestCase {
+  query: string;
+  expected_skills: string[];
+}
+
+interface Fixture {
+  test_cases: TestCase[];
+}
+
+const CHIPSET_ROOT = join(__dirname, '../../examples/chipsets/rca-department');
+const chipset: Chipset = parse(readFileSync(join(CHIPSET_ROOT, 'chipset.yaml'), 'utf8'));
+const fixture: Fixture = parse(readFileSync(join(CHIPSET_ROOT, 'benchmark/test-cases.yaml'), 'utf8'));
+
+const REQUIRED_METHODOLOGIES = [
+  'rca-classical-methods',
+  'rca-systems-theoretic',
+  'rca-causal-inference',
+  'rca-human-factors',
+  'rca-distributed-systems',
+];
+
+const REQUIRED_GROVE_TYPES = [
+  'RCAInvestigation',
+  'RCAFinding',
+  'RCACausalGraph',
+  'RCAPostmortem',
+  'RCASession',
+];
+
+describe('rca-department chipset', () => {
+  describe('structural invariants (brief done-criteria)', () => {
+    it('lists exactly 6 skills, 5 agents, 3 teams, 5 grove record types', () => {
+      expect(Object.keys(chipset.skills)).toHaveLength(6);
+      expect(chipset.agents.agents).toHaveLength(5);
+      expect(Object.keys(chipset.teams)).toHaveLength(3);
+      expect(chipset.grove.record_types).toHaveLength(5);
+    });
+
+    it('name is rca-department-v1.0', () => {
+      expect(chipset.name).toBe('rca-department-v1.0');
+    });
+  });
+
+  describe('pre_deploy gates', () => {
+    it('all_skills_have_descriptions', () => {
+      for (const [name, skill] of Object.entries(chipset.skills)) {
+        expect(skill.description?.trim().length, `${name} description`).toBeGreaterThan(0);
+      }
+    });
+
+    it('all_agents_have_roles', () => {
+      for (const agent of chipset.agents.agents) {
+        expect(agent.role?.trim().length, `${agent.name} role`).toBeGreaterThan(0);
+      }
+    });
+
+    it('grove_record_types_defined (5 RCA types present)', () => {
+      const actual = chipset.grove.record_types.map((r) => r.name);
+      for (const required of REQUIRED_GROVE_TYPES) {
+        expect(actual, `missing grove type ${required}`).toContain(required);
+      }
+    });
+
+    it('router_agent_is_capcom and exactly one capcom exists', () => {
+      const router = chipset.agents.router_agent;
+      const routerAgent = chipset.agents.agents.find((a) => a.name === router);
+      expect(routerAgent, `router agent ${router} must exist`).toBeDefined();
+      expect(routerAgent?.is_capcom, `${router} is_capcom`).toBe(true);
+      const capcoms = chipset.agents.agents.filter((a) => a.is_capcom === true);
+      expect(capcoms, 'exactly one capcom').toHaveLength(1);
+    });
+
+    it('all_methodologies_covered (5 RCA methodology skills)', () => {
+      for (const m of REQUIRED_METHODOLOGIES) {
+        expect(chipset.skills[m], `methodology skill ${m}`).toBeDefined();
+      }
+    });
+  });
+
+  describe('referential integrity', () => {
+    it('skill agent_affinity references only real agents', () => {
+      const names = new Set(chipset.agents.agents.map((a) => a.name));
+      for (const [skillName, skill] of Object.entries(chipset.skills)) {
+        const affinities = Array.isArray(skill.agent_affinity)
+          ? skill.agent_affinity
+          : [skill.agent_affinity];
+        for (const a of affinities) {
+          expect(names.has(a), `${skillName} affinity ${a} not in agent roster`).toBe(true);
+        }
+      }
+    });
+
+    it('team members reference only real agents', () => {
+      const names = new Set(chipset.agents.agents.map((a) => a.name));
+      for (const [teamName, team] of Object.entries(chipset.teams)) {
+        for (const a of team.agents) {
+          expect(names.has(a), `${teamName} member ${a} not in agent roster`).toBe(true);
+        }
+      }
+    });
+
+    it('college binding is explicitly opted out (deliberate divergence)', () => {
+      expect(chipset.college.department).toBeNull();
+      expect(chipset.college.concept_graph.read).toBe(false);
+      expect(chipset.college.concept_graph.write).toBe(false);
+      expect(chipset.college.wings).toEqual([]);
+    });
+  });
+
+  describe('trigger benchmark', () => {
+    it('fixture has at least test_cases_minimum cases', () => {
+      expect(fixture.test_cases.length).toBeGreaterThanOrEqual(
+        chipset.evaluation.benchmark.test_cases_minimum,
+      );
+    });
+
+    it('every expected skill in fixture exists in chipset', () => {
+      for (const tc of fixture.test_cases) {
+        for (const s of tc.expected_skills) {
+          expect(chipset.skills[s], `test-case expected skill ${s}`).toBeDefined();
+        }
+      }
+    });
+
+    it('trigger accuracy meets threshold', () => {
+      const matchSkill = (query: string): Set<string> => {
+        const q = query.toLowerCase();
+        const hits = new Set<string>();
+        for (const [name, skill] of Object.entries(chipset.skills)) {
+          for (const trigger of skill.triggers) {
+            if (q.includes(trigger.toLowerCase())) {
+              hits.add(name);
+              break;
+            }
+          }
+        }
+        return hits;
+      };
+
+      let correct = 0;
+      const misses: string[] = [];
+      for (const tc of fixture.test_cases) {
+        const matched = matchSkill(tc.query);
+        const hit = tc.expected_skills.some((s) => matched.has(s));
+        if (hit) {
+          correct++;
+        } else {
+          misses.push(`"${tc.query}" → expected ${tc.expected_skills.join(',')}, matched ${[...matched].join(',') || 'none'}`);
+        }
+      }
+      const accuracy = correct / fixture.test_cases.length;
+      expect(
+        accuracy,
+        `trigger accuracy ${accuracy.toFixed(3)} below threshold ${chipset.evaluation.benchmark.trigger_accuracy_threshold}\nMisses:\n  ${misses.join('\n  ')}`,
+      ).toBeGreaterThanOrEqual(chipset.evaluation.benchmark.trigger_accuracy_threshold);
+    });
+  });
+});


### PR DESCRIPTION
Retroactively completes Session 020 RCA artifact suite by binding 6 skills, 5 agents, 3 teams into a forkable department chipset. Follows math-department template pattern. Ships 30-case trigger benchmark + 13-test gate enforcement (all 13 passing in 353ms). No college integration — RCA is cross-cutting reliability infrastructure (README §7). See commit 52625ee44 for full detail. Session 020 commits: df7731df5, f0c7358e1, 59d271e90. Research grounding: docs/research/rca-deep/. Pre-existing dev failures (harness-integrity adversarial-pr-review, dashboard timeout) unrelated.